### PR TITLE
Improve board data fetch fallback logic

### DIFF
--- a/prop-scraper/src/app/api/lines/route.ts
+++ b/prop-scraper/src/app/api/lines/route.ts
@@ -35,12 +35,17 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: "Failed to fetch data" }, { status: 500 });
     }
 
-    const data = await resp.json();
+    const data: unknown = await resp.json();
+    const projections = Array.isArray((data as { data?: unknown[] }).data)
+      ? (data as { data: unknown[] }).data
+      : [];
+    type Projection = { attributes?: { name?: string; stat_type?: string; line_score?: number } };
     const searchName = normalizeString(playerName);
 
-    const projection = data.data.find((p: any) =>
-      normalizeString(p.attributes?.name || "").includes(searchName) &&
-      normalizeString(p.attributes?.stat_type || "") === "pitcher strikeouts"
+    const projection = (projections as Projection[]).find(
+      (p) =>
+        normalizeString(p.attributes?.name || "").includes(searchName) &&
+        normalizeString(p.attributes?.stat_type || "") === "pitcher strikeouts"
     );
 
     if (projection) {

--- a/prop-scraper/src/app/api/players/route.ts
+++ b/prop-scraper/src/app/api/players/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 
 type Player = { id: string; name: string; team?: string };
+type RawTeam = { id: number; abbreviation: string };
+type RosterEntry = { person: { id: number; fullName: string } };
 
 // Revalidate every 6 hours so we don't hammer the API
 export const revalidate = 60 * 60 * 6;
@@ -15,17 +17,25 @@ export async function GET() {
     // 1) fetch all MLB teams
     const teamsRes = await fetch("https://statsapi.mlb.com/api/v1/teams?sportId=1&activeStatus=Y");
     if (!teamsRes.ok) throw new Error("Teams fetch failed");
-    const teamsData = await teamsRes.json();
-    const teams: Array<{ id: number; abbr: string }> =
-      (teamsData?.teams || []).map((t: any) => ({ id: t.id, abbr: t.abbreviation }));
+    const teamsData: unknown = await teamsRes.json();
+    const rawTeams = Array.isArray((teamsData as { teams?: unknown[] }).teams)
+      ? (teamsData as { teams: unknown[] }).teams
+      : [];
+    const teams: Array<{ id: number; abbr: string }> = (rawTeams as RawTeam[]).map((t) => ({
+      id: t.id,
+      abbr: t.abbreviation,
+    }));
 
     // 2) fetch each team’s active roster
     const rosterArrays = await Promise.all(
       teams.map(async (t) => {
         const r = await fetch(`https://statsapi.mlb.com/api/v1/teams/${t.id}/roster?rosterType=active`);
         if (!r.ok) return [];
-        const j = await r.json();
-        const players: Player[] = (j?.roster || []).map((e: any) => ({
+        const j: unknown = await r.json();
+        const roster = Array.isArray((j as { roster?: unknown[] }).roster)
+          ? (j as { roster: unknown[] }).roster
+          : [];
+        const players: Player[] = (roster as RosterEntry[]).map((e) => ({
           id: String(e.person.id),
           name: String(e.person.fullName),
           team: t.abbr,

--- a/prop-scraper/src/app/page.tsx
+++ b/prop-scraper/src/app/page.tsx
@@ -319,7 +319,7 @@ async function loadBoardData(): Promise<APIPick[]> {
       const data = await res.json();
       // Expect either array or { picks: [...] }
       const arr = Array.isArray(data) ? data : Array.isArray(data?.picks) ? data.picks : null;
-      if (arr && arr.length >= 0) {
+      if (arr && arr.length > 0) {
         // Normalize a bit
         return arr.map((x: any) => ({
           id: x.id ?? `${x.player}-${x.platform}-${x.sport}`,

--- a/prop-scraper/src/app/page.tsx
+++ b/prop-scraper/src/app/page.tsx
@@ -316,20 +316,24 @@ async function loadBoardData(): Promise<APIPick[]> {
     try {
       const res = await fetch(url, { cache: "no-store" });
       if (!res.ok) continue;
-      const data = await res.json();
+      const data: unknown = await res.json();
       // Expect either array or { picks: [...] }
-      const arr = Array.isArray(data) ? data : Array.isArray(data?.picks) ? data.picks : null;
-      if (arr && arr.length > 0) {
+      const arr: unknown = Array.isArray(data)
+        ? data
+        : typeof data === "object" && data !== null && Array.isArray((data as { picks?: unknown }).picks)
+        ? (data as { picks: unknown[] }).picks
+        : null;
+      if (Array.isArray(arr) && arr.length > 0) {
         // Normalize a bit
-        return arr.map((x: any) => ({
+        return (arr as Partial<APIPick>[]).map((x) => ({
           id: x.id ?? `${x.player}-${x.platform}-${x.sport}`,
-          sport: x.sport,
-          player: x.player,
+          sport: x.sport!,
+          player: x.player!,
           team: x.team,
-          platform: x.platform,
+          platform: x.platform!,
           statUnit: x.statUnit ?? "",
           line: Number(x.line),
-          pickSide: x.pickSide,
+          pickSide: x.pickSide!,
           overMultiplier: typeof x.overMultiplier === "number" ? x.overMultiplier : undefined,
           underMultiplier: typeof x.underMultiplier === "number" ? x.underMultiplier : undefined,
           confidence: typeof x.confidence === "number" ? x.confidence : undefined,


### PR DESCRIPTION
## Summary
- require non-empty array when fetching board data so fallback endpoints are used

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any types)


------
https://chatgpt.com/codex/tasks/task_e_689cffce45ec8328a1d70ce110a10d36